### PR TITLE
Add Default Download Path

### DIFF
--- a/pymeu/main.py
+++ b/pymeu/main.py
@@ -5,7 +5,6 @@ from warnings import warn
 from . import terminal
 from . import types
 
-
 class MEUtility(object):
     def __init__(self, comms_path: str, **kwargs):
         """
@@ -51,6 +50,9 @@ class MEUtility(object):
         self.replace_comms = kwargs.get('replace_comms', False)
         self.remote_file_name = kwargs.get('remote_file_name', os.path.basename(file_path))
         self.run_at_startup = kwargs.get('run_at_startup', True)
+
+        if ("\\" or "/") not in file_path:
+            file_path = "C:\\Users\\Public\\Documents\\RSView Enterprise\\ME\\Runtime\\" + file_path
 
         with pycomm3.CIPDriver(self.comms_path) as cip:
             file = types.MEFile(self.remote_file_name, self.overwrite, False, file_path)

--- a/pymeu/main.py
+++ b/pymeu/main.py
@@ -52,10 +52,8 @@ class MEUtility(object):
         self.run_at_startup = kwargs.get('run_at_startup', True)
 
         if not os.path.isfile(file_path):
-            print(file_path)
             if ("\\" or "/") not in file_path:
                 file_path = "C:\\Users\\Public\\Documents\\RSView Enterprise\\ME\\Runtime\\" + file_path
-            print(f'new: {file_path}')
 
         with pycomm3.CIPDriver(self.comms_path) as cip:
             file = types.MEFile(self.remote_file_name, self.overwrite, False, file_path)

--- a/pymeu/main.py
+++ b/pymeu/main.py
@@ -51,8 +51,11 @@ class MEUtility(object):
         self.remote_file_name = kwargs.get('remote_file_name', os.path.basename(file_path))
         self.run_at_startup = kwargs.get('run_at_startup', True)
 
-        if ("\\" or "/") not in file_path:
-            file_path = "C:\\Users\\Public\\Documents\\RSView Enterprise\\ME\\Runtime\\" + file_path
+        if not os.path.isfile(file_path):
+            print(file_path)
+            if ("\\" or "/") not in file_path:
+                file_path = "C:\\Users\\Public\\Documents\\RSView Enterprise\\ME\\Runtime\\" + file_path
+            print(f'new: {file_path}')
 
         with pycomm3.CIPDriver(self.comms_path) as cip:
             file = types.MEFile(self.remote_file_name, self.overwrite, False, file_path)


### PR DESCRIPTION
I added this to a program I had created on top of this library and thought I'd see if there was interest in rolling it in to the library. If not, no big deal.

The default location that View Studio ME wants to save MER files to is "C:\Users\Public\Documents\RSView Enterprise\ME\Runtime". If you're using this library in the interpreter to quickly download a file, you either have to click through windows explorer to save to a less lengthy path, or type this entire path each time you call MEUtility.download(). 

This simply checks if the passed file path is a file in the CWD, and if not, checks if the passed path contains any slashes. If both of those are false, it adds the above default path to the MER file and continues on. 

This might not be the best way to implement this, but any other way using pathlib caused issues. 