### PR TITLE
Improve decompression performance

### DIFF
--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -97,6 +97,11 @@ def decompress_stream(
     progress_desc: str = None,
     progress: Optional[Callable[[str, str, int, int], None]] = None
 ) -> bytearray:
+    # If the stream is too short it can't contain
+    # a compressed stream and will be returned directly.
+    if (len(input) < 4): return input.tobytes()
+
+    # Split compressed stream into pages
     stream_offset = 0
     stream_length = len(input)
     stream_page_compressed: list[memoryview] = []
@@ -107,15 +112,17 @@ def decompress_stream(
         stream_offset += page_length
         stream_page_compressed.append(page_mv)
 
+    # If the offsets don't add up this stream doesn't follow
+    # the expected format and will be returned directly.
+    if (stream_offset != len(input)): return input.tobytes()
+
+    # Decompress each page separately
     workers = os.cpu_count() or 1
     page_bytes_list = [mv.tobytes() for mv in stream_page_compressed]
-    try:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
-            stream_page_decompressed: list[bytearray] = list(pool.map(decompress_page, page_bytes_list))
-    except Exception as ex:
-        print(ex)
-        raise(Exception(ex))
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        stream_page_decompressed: list[bytearray] = list(pool.map(decompress_page, page_bytes_list))
 
+    # Concatenate pages into decompressed stream
     output_length = sum(len(x) for x in stream_page_decompressed)
     output = bytearray(output_length)
     output_offset = 0
@@ -182,7 +189,7 @@ def decompress_archive(
                 #
                 # Is there a better way to retain them and still
                 # print exceptions for failed decompressions?
-                #print(e)
+                print(e)
                 pass
 
             stream_info = types.MEArchive(

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from concurrent.futures import ProcessPoolExecutor
 import olefile
 import os
 import struct
@@ -92,7 +93,7 @@ def decompress_page(input: memoryview) -> bytearray:
     return page_decompressed
 
 def decompress_stream(
-    input: bytearray,
+    input: memoryview,
     progress_desc: str = None,
     progress: Optional[Callable[[str, str, int, int], None]] = None
 ) -> bytearray:
@@ -106,14 +107,17 @@ def decompress_stream(
         stream_offset += page_length
         stream_page_compressed.append(page_mv)
 
-    stream_page_decompressed: list[bytearray] = []
-    stream_length_decompressed = 0
-    for page in stream_page_compressed:
-        page_decompressed = decompress_page(page)
-        stream_length_decompressed += len(page_decompressed)
-        stream_page_decompressed.append(page_decompressed)
+    workers = os.cpu_count() or 1
+    page_bytes_list = [mv.tobytes() for mv in stream_page_compressed]
+    try:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            stream_page_decompressed: list[bytearray] = list(pool.map(decompress_page, page_bytes_list))
+    except Exception as ex:
+        print(ex)
+        raise(Exception(ex))
 
-    output = bytearray(stream_length_decompressed)
+    output_length = sum(len(x) for x in stream_page_decompressed)
+    output = bytearray(output_length)
     output_offset = 0
     for page in stream_page_decompressed:
         page_len = len(page)

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from . import types
 
+PAGE_HEADER_SIZE_BYTES = 4
 PAGE_SIZE_BYTES = 32768
 CHUNK_SIZE_TOKENS = 16
 
@@ -65,8 +66,8 @@ def decompress_page(input: memoryview) -> bytearray:
     page_length = len(input)
 
     # If the page is uncompressed already, return as-is
-    page_control = input[page_offset:page_offset + 4]
-    page_offset += 4
+    page_control = input[page_offset:page_offset + PAGE_HEADER_SIZE_BYTES]
+    page_offset += PAGE_HEADER_SIZE_BYTES
     if (page_control[0] == 0x01): return bytearray(input[page_offset:])
 
     # Split the page into chunks
@@ -90,7 +91,11 @@ def decompress_page(input: memoryview) -> bytearray:
     if (page_decompressed_offset < PAGE_SIZE_BYTES): page_decompressed = page_decompressed[:page_decompressed_offset]
     return page_decompressed
 
-def decompress_stream(input: memoryview) -> bytearray:
+def decompress_stream(
+    input: bytearray,
+    progress_desc: str = None,
+    progress: Optional[Callable[[str, str, int, int], None]] = None
+) -> bytearray:
     stream_offset = 0
     stream_length = len(input)
     stream_page_compressed: list[memoryview] = []
@@ -163,8 +168,8 @@ def decompress_archive(
             stream_data = ole.openstream(original_name).read()
             try:
                 print(stream_name)
-                stream_data = _decompress_stream(
-                    input=stream_data,
+                stream_data = decompress_stream(
+                    input=memoryview(stream_data),
                     progress_desc=stream_name,
                     progress=progress
                 )

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -129,12 +129,14 @@ def decompress_stream(
     workers = os.cpu_count() or 1
     page_bytes_list = [mv.tobytes() for mv in stream_page_compressed]
     completed_bytes = 0
+    stream_page_decompressed: list[bytearray] = []
     with ProcessPoolExecutor(max_workers=workers) as pool:
-        stream_page_decompressed: list[bytearray] = list(pool.map(decompress_page, page_bytes_list))
+        decompressed_iterator = pool.map(decompress_page, page_bytes_list)
+        for i, decompressed_page in enumerate(decompressed_iterator):
+            stream_page_decompressed.append(decompressed_page)
 
-        # Optional progress indication
-        if progress:
-            for i, _ in enumerate(stream_page_decompressed):
+            # Optional progress indication
+            if progress:
                 completed_bytes += len(page_bytes_list[i])
                 progress(f'Decompressing {progress_desc or 'stream'}', 'bytes', stream_length, completed_bytes)
 

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -66,6 +66,9 @@ def decompress_page(input: memoryview) -> bytearray:
     page_offset = 0
     page_length = len(input)
 
+    # If the page is too short, return as-is
+    if (page_length < 4): return bytearray(input[page_offset:])
+
     # If the page is uncompressed already, return as-is
     page_control = input[page_offset:page_offset + PAGE_HEADER_SIZE_BYTES]
     page_offset += PAGE_HEADER_SIZE_BYTES
@@ -106,6 +109,11 @@ def decompress_stream(
     stream_length = len(input)
     stream_page_compressed: list[memoryview] = []
     while (stream_offset < stream_length):
+        # If the stream is too short it can't contain
+        # another page definition, the stream doesn't follow
+        # the expected format and will be returned directly.
+        if (stream_length - stream_offset) < 4: return input.tobytes()
+
         page_length = struct.unpack_from('I', input, stream_offset)[0]
         stream_offset += 4
         page_mv = input[stream_offset:stream_offset + page_length]
@@ -177,21 +185,12 @@ def decompress_archive(
                 continue
             
             stream_data = ole.openstream(original_name).read()
-            try:
-                print(stream_name)
-                stream_data = decompress_stream(
-                    input=memoryview(stream_data),
-                    progress_desc=stream_name,
-                    progress=progress
-                )
-            except Exception as e:
-                # Some streams aren't compressed.
-                #
-                # Is there a better way to retain them and still
-                # print exceptions for failed decompressions?
-                print(e)
-                pass
-
+            print(stream_name)
+            stream_data = decompress_stream(
+                input=memoryview(stream_data),
+                progress_desc=stream_name,
+                progress=progress
+            )
             stream_info = types.MEArchive(
                 name=stream_name,
                 data=stream_data,

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -128,8 +128,18 @@ def decompress_stream(
     # Decompress each page separately
     workers = os.cpu_count() or 1
     page_bytes_list = [mv.tobytes() for mv in stream_page_compressed]
+    completed_bytes = 0
     with ProcessPoolExecutor(max_workers=workers) as pool:
         stream_page_decompressed: list[bytearray] = list(pool.map(decompress_page, page_bytes_list))
+
+        # Optional progress indication
+        if progress:
+            for i, _ in enumerate(stream_page_decompressed):
+                completed_bytes += len(page_bytes_list[i])
+                progress(f'Decompressing {progress_desc or 'stream'}', 'bytes', stream_length, completed_bytes)
+
+    # Optional progress indication
+    if progress: progress(f'Decompressing {progress_desc or 'stream'}', 'bytes', stream_length, stream_length)
 
     # Concatenate pages into decompressed stream
     output_length = sum(len(x) for x in stream_page_decompressed)

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -6,164 +6,115 @@ from typing import Optional
 
 from . import types
 
-
-CHUNK_CONTROL_SIZE_BYTES = 2
-CHUNK_DATA_SIZE_TOKENS = 16
-PAGE_HEADER_SIZE_BYTES = 4
-TOKEN_LITERAL_SIZE_BYTES = 1
-TOKEN_POINTER_SIZE_BYTES = 2
+PAGE_SIZE_BYTES = 32768
+CHUNK_SIZE_TOKENS = 16
 
 STREAM_NAME_MAPPEE = '__MAPPEE'
 STREAM_NAME_MAPPER = '__MAPPER'
 
-def _get_int8_nibbles(value: int) -> tuple[int, int]:
-    high_nibble = (value >> 4) & 0x0F
-    low_nibble = value & 0x0F
-    return low_nibble, high_nibble
-
-def _get_pointer_values(input: memoryview) -> tuple[int, int]:
+def get_pointer_values(input: memoryview) -> tuple[int, int]:
     if len(input) != 2: raise ValueError("Input must be exactly 2 bytes long")
-    (length, offset_msb) = _get_int8_nibbles(input[0])
-    offset_lsb = input[1]
-    offset = (offset_msb << 8) | offset_lsb
-    length += 1
+    length = (input[0] & 0x0F) + 1
+    offset = ((input[0] >> 4) << 8) | input[1]
     return length, offset
 
-def _get_expected_chunk_length(input: int) -> int:
-    # Each chunk is made up of a fixed number of tokens.
-    # Some are pointers (2 bytes), the rest are literals (1 byte).
-    pointers = int.from_bytes(input, byteorder='little').bit_count()
-    literals = CHUNK_DATA_SIZE_TOKENS - pointers
-    length = (pointers * TOKEN_POINTER_SIZE_BYTES) + (literals * TOKEN_LITERAL_SIZE_BYTES)
-    return length
+def is_pointer(input: int, bit: int) -> bool:
+    return bool((input >> bit) & 1)
 
-def _is_pointer(control: int, index: int) -> bool:
-    return bool((control >> index) & 1)
-'''
-def _decompress_chunk(input: bytearray, control: int, data: memoryview, length: int) -> bytearray:
-    output = bytearray(input)
-
-    # Each chunk is comprised of a fixed number of tokens (some literal, some pointers)
-    byte_index = 0
-    for data_index in range(CHUNK_DATA_SIZE_TOKENS):
-        if _is_pointer(control, data_index):
-            token_bytes = data[byte_index:byte_index+TOKEN_POINTER_SIZE_BYTES]
-            (token_length, token_offset) = _get_pointer_values(memoryview(token_bytes))
-
-            head = len(output)
-            token_index = 0
-            while (token_index < token_length):
-                if (token_offset > 0):
-                    # Normally look back and slide forward.
-                    # This allows for the case where the length is
-                    # greater than the offset, so part of the new bytes
-                    # ends up used again within the same substitution.
-                    output.append(output[head - token_offset + token_index])
-                else:
-                    # Offset zero is a special case where the last char
-                    # is just repeated.
-                    output.append(output[head - 1])
-                token_index += 1
-
-            byte_index += TOKEN_POINTER_SIZE_BYTES
+def decompress_token(page_decompressed: bytearray, page_offset: int, token_length: int, token_offset: int):
+    # This is a slower but functional decompression that slides byte by byte across
+    # the array.
+    token_index = 0
+    while (token_index < token_length):
+        if (token_offset > 0):
+            page_decompressed[page_offset + token_index] = page_decompressed[page_offset - token_offset + token_index]
         else:
-            output.append(data[byte_index])
-            byte_index += TOKEN_LITERAL_SIZE_BYTES
-        
-        if byte_index >= length: break
+            page_decompressed[page_offset + token_index] = page_decompressed[page_offset - 1]
+        token_index += 1
 
-    return output[len(input):]
-'''
+def decompress_token_fast(page_decompressed: bytearray, page_offset: int, token_length: int, token_offset: int):
+    # This is a faster but broken decompression since it copies the data all at once.
+    # If the token extends beyond where page_offset started, it is inacurrate.
+    if token_offset > 0:
+        page_decompressed[page_offset:page_offset + token_length] = page_decompressed[page_offset - token_offset:page_offset - token_offset + token_length]
+    else:
+        page_decompressed[page_offset:page_offset + token_length] = [page_decompressed[page_offset - 1]] * token_length
 
-def _decompress_chunk(
-    context: memoryview,
-    control: int,
-    data: memoryview,
-    length: int
-) -> bytearray:
-    output = bytearray()
-
+def decompress_chunk(page_decompressed: bytearray, chunk_data: memoryview, chunk_control: int, page_offset: int) -> int:
     chunk_offset = 0
-    for token_index in range(CHUNK_DATA_SIZE_TOKENS):
-        if _is_pointer(control, token_index):
-            (token_length, token_offset) = _get_pointer_values(data[chunk_offset:chunk_offset + TOKEN_POINTER_SIZE_BYTES])
-            head = len(output)
-            print(f'{token_offset} {token_length}')
+    chunk_token_count = len(chunk_data) - chunk_control.bit_count()
+    for x in range(chunk_token_count):
+        if is_pointer(chunk_control, x):
+            token_length, token_offset = get_pointer_values(chunk_data[chunk_offset:chunk_offset + 2])
+            chunk_offset += 2
 
-            '''
-            look_back_length = token_length - head
-            if (look_back_length > 0):
-                output.append(context[-look_back_length:])
-                token_length -= look_back_length
+            if (token_length > token_offset):
+                decompress_token(page_decompressed=page_decompressed, page_offset=page_offset, token_length=token_length, token_offset=token_offset)
+            else:
+                decompress_token_fast(page_decompressed=page_decompressed, page_offset=page_offset, token_length=token_length, token_offset=token_offset)
+            page_offset += token_length
 
-            output.append(output[])
-            '''
         else:
-            output.append(data[token_index])
-    return output
+            page_decompressed[page_offset] = chunk_data[chunk_offset]
+            chunk_offset += 1
+            page_offset += 1
+    return page_offset
 
-def _decompress_page(
-    input: memoryview
-) -> bytearray:
+def decompress_page(input: memoryview) -> bytearray:
     page_offset = 0
     page_length = len(input)
-    output = bytearray()
 
-    # If this page is uncompressed, return the data portion as-is
-    page_control_bytes = memoryview(input[page_offset:page_offset + PAGE_HEADER_SIZE_BYTES])
-    page_offset += PAGE_HEADER_SIZE_BYTES
-    if (page_control_bytes[0] == 0x01): return memoryview(input[page_offset:])
+    # If the page is uncompressed already, return as-is
+    page_control = input[page_offset:page_offset + 4]
+    page_offset += 4
+    if (page_control[0] == 0x01): return bytearray(input[page_offset:])
 
-    # Otherwise decompress each chunk and append them
+    # Split the page into chunks
+    page_decompressed = bytearray(PAGE_SIZE_BYTES)
+    page_decompressed_offset = 0
     while (page_offset < page_length):
-        chunk_control_int = struct.unpack_from('H', input, page_offset)[0]
+        # Two bytes for control bits
+        chunk_control: int = struct.unpack_from('H', input, page_offset)[0]
         page_offset += 2
-        chunk_length = _get_expected_chunk_length(chunk_control_int)
-        chunk_data_bytes = input[page_offset:page_offset + chunk_length]
-        page_offset += chunk_length
 
-        output.append(_decompress_chunk(context=memoryview(output), 
-                                        control=chunk_control_int, 
-                                        data=chunk_data_bytes, 
-                                        length=chunk_length))
+        # One byte for each token, plus one byte for each of the pointers
+        # since they are two bytes each.
+        chunk_length_expected = chunk_control.bit_count() + CHUNK_SIZE_TOKENS
+        chunk_data = input[page_offset:page_offset + chunk_length_expected]
+        page_offset += len(chunk_data)
 
-    return output
+        # Decompressed offset is cumulative
+        page_decompressed_offset = decompress_chunk(page_decompressed=page_decompressed, chunk_data=chunk_data, chunk_control=chunk_control, page_offset=page_decompressed_offset)
 
-def _decompress_stream(
-    input: memoryview,
-    progress_desc: str = None,
-    progress: Optional[Callable[[str, str, int, int], None]] = None
-) -> bytearray:
+    # Typically the last page of the stream could be less than the preallocated size
+    if (page_decompressed_offset < PAGE_SIZE_BYTES): page_decompressed = page_decompressed[:page_decompressed_offset]
+    return page_decompressed
 
-    # Break the stream into a set of pages
+def decompress_stream(input: memoryview) -> bytearray:
     stream_offset = 0
     stream_length = len(input)
-    stream_pages_compressed = []
-    stream_pages_length = []
+    stream_page_compressed: list[memoryview] = []
     while (stream_offset < stream_length):
         page_length = struct.unpack_from('I', input, stream_offset)[0]
         stream_offset += 4
-        page_mv = memoryview(input[stream_offset:stream_offset + page_length])
+        page_mv = input[stream_offset:stream_offset + page_length]
         stream_offset += page_length
-        stream_pages_compressed.append(page_mv)
-        stream_pages_length.append(page_length + 4)
+        stream_page_compressed.append(page_mv)
 
-    # Decompress each page separately
-    # No context is shared across pages
-    stream_pages_decompressed = []
-    stream_pages_progress = 0
-    print(len(stream_pages_length))
-    for (page, length) in zip(stream_pages_compressed, stream_pages_length):
-        stream_pages_decompressed.append(_decompress_page(page))
-        if progress:
-            stream_pages_progress += length
-            desc = f'Decompressing'
-            if progress_desc: desc += f' {progress_desc}'
-            progress(desc, 'bytes', stream_length, stream_pages_progress)
+    stream_page_decompressed: list[bytearray] = []
+    stream_length_decompressed = 0
+    for page in stream_page_compressed:
+        page_decompressed = decompress_page(page)
+        stream_length_decompressed += len(page_decompressed)
+        stream_page_decompressed.append(page_decompressed)
 
-    # Concatenate output
-    output = bytearray()
-    for page in stream_pages_decompressed: output.extend(page)
+    output = bytearray(stream_length_decompressed)
+    output_offset = 0
+    for page in stream_page_decompressed:
+        page_len = len(page)
+        output[output_offset:output_offset + page_len] = page
+        output_offset += page_len
+
     return output
 
 def _create_subfolders(output_path: str, archive_paths: list[str]):

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -97,22 +97,23 @@ def decompress_page(input: memoryview) -> bytearray:
 
 def decompress_stream(
     input: memoryview,
-    progress_desc: str = None,
+    progress_desc: str | None = None,
     progress: Optional[Callable[[str, str, int, int], None]] = None
 ) -> bytearray:
-    # If the stream is too short it can't contain
-    # a compressed stream and will be returned directly.
-    if (len(input) < 4): return input.tobytes()
-
-    # Split compressed stream into pages
     stream_offset = 0
     stream_length = len(input)
+
+    # If the stream is too short it can't contain
+    # a compressed stream and will be returned directly.
+    if (stream_length < 4): return bytearray(input.tobytes())
+
+    # Split compressed stream into pages
     stream_page_compressed: list[memoryview] = []
     while (stream_offset < stream_length):
         # If the stream is too short it can't contain
         # another page definition, the stream doesn't follow
         # the expected format and will be returned directly.
-        if (stream_length - stream_offset) < 4: return input.tobytes()
+        if (stream_length - stream_offset) < 4: return bytearray(input.tobytes())
 
         page_length = struct.unpack_from('I', input, stream_offset)[0]
         stream_offset += 4
@@ -122,7 +123,7 @@ def decompress_stream(
 
     # If the offsets don't add up this stream doesn't follow
     # the expected format and will be returned directly.
-    if (stream_offset != len(input)): return input.tobytes()
+    if (stream_offset != stream_length): return bytearray(input.tobytes())
 
     # Decompress each page separately
     workers = os.cpu_count() or 1

--- a/pymeu/me/decompress.py
+++ b/pymeu/me/decompress.py
@@ -1,14 +1,14 @@
 from collections.abc import Callable
 import olefile
 import os
+import struct
 from typing import Optional
 
 from . import types
 
+
 CHUNK_CONTROL_SIZE_BYTES = 2
 CHUNK_DATA_SIZE_TOKENS = 16
-PAGE_CONTEXT_SIZE_BYTES = 4095
-PAGE_CONTROL_SIZE_BYTES = 4
 PAGE_HEADER_SIZE_BYTES = 4
 TOKEN_LITERAL_SIZE_BYTES = 1
 TOKEN_POINTER_SIZE_BYTES = 2
@@ -16,28 +16,31 @@ TOKEN_POINTER_SIZE_BYTES = 2
 STREAM_NAME_MAPPEE = '__MAPPEE'
 STREAM_NAME_MAPPER = '__MAPPER'
 
-def _get_int8_nibbles(value: int):
+def _get_int8_nibbles(value: int) -> tuple[int, int]:
     high_nibble = (value >> 4) & 0x0F
     low_nibble = value & 0x0F
-    return (low_nibble, high_nibble)
+    return low_nibble, high_nibble
 
-def _get_pointer_values(bytes: bytearray):
-    (length, offset_msb) = _get_int8_nibbles(bytes[0])
-    offset_lsb = bytes[1]
-    offset = (offset_msb << 8) + offset_lsb
+def _get_pointer_values(input: memoryview) -> tuple[int, int]:
+    if len(input) != 2: raise ValueError("Input must be exactly 2 bytes long")
+    (length, offset_msb) = _get_int8_nibbles(input[0])
+    offset_lsb = input[1]
+    offset = (offset_msb << 8) | offset_lsb
     length += 1
-    return (length, offset)
+    return length, offset
 
-def _get_expected_chunk_length(bytes) -> int:
-    tokens = int.from_bytes(bytes, byteorder='little').bit_count()
-    literals = CHUNK_DATA_SIZE_TOKENS - tokens
-    length = (tokens * 2) + literals
+def _get_expected_chunk_length(input: int) -> int:
+    # Each chunk is made up of a fixed number of tokens.
+    # Some are pointers (2 bytes), the rest are literals (1 byte).
+    pointers = int.from_bytes(input, byteorder='little').bit_count()
+    literals = CHUNK_DATA_SIZE_TOKENS - pointers
+    length = (pointers * TOKEN_POINTER_SIZE_BYTES) + (literals * TOKEN_LITERAL_SIZE_BYTES)
     return length
 
 def _is_pointer(control: int, index: int) -> bool:
     return bool((control >> index) & 1)
-
-def _decompress_chunk(input: bytearray, control: int, data: bytearray, length: int) -> bytearray:
+'''
+def _decompress_chunk(input: bytearray, control: int, data: memoryview, length: int) -> bytearray:
     output = bytearray(input)
 
     # Each chunk is comprised of a fixed number of tokens (some literal, some pointers)
@@ -45,7 +48,7 @@ def _decompress_chunk(input: bytearray, control: int, data: bytearray, length: i
     for data_index in range(CHUNK_DATA_SIZE_TOKENS):
         if _is_pointer(control, data_index):
             token_bytes = data[byte_index:byte_index+TOKEN_POINTER_SIZE_BYTES]
-            (token_length, token_offset) = _get_pointer_values(token_bytes)
+            (token_length, token_offset) = _get_pointer_values(memoryview(token_bytes))
 
             head = len(output)
             token_index = 0
@@ -70,59 +73,97 @@ def _decompress_chunk(input: bytearray, control: int, data: bytearray, length: i
         if byte_index >= length: break
 
     return output[len(input):]
+'''
 
-def _decompress_page(input: bytearray) -> bytearray:
+def _decompress_chunk(
+    context: memoryview,
+    control: int,
+    data: memoryview,
+    length: int
+) -> bytearray:
     output = bytearray()
-    length = len(input)
-    offset = 0
-    page_control_bytes = input[offset:offset + PAGE_CONTROL_SIZE_BYTES]
-    offset += PAGE_CONTROL_SIZE_BYTES
 
-    # If page is not compressed, return the rest of the page as-is
-    if (page_control_bytes[0] == 0x01):
-        output = input[offset:]
-        return output
+    chunk_offset = 0
+    for token_index in range(CHUNK_DATA_SIZE_TOKENS):
+        if _is_pointer(control, token_index):
+            (token_length, token_offset) = _get_pointer_values(data[chunk_offset:chunk_offset + TOKEN_POINTER_SIZE_BYTES])
+            head = len(output)
+            print(f'{token_offset} {token_length}')
 
-    # Then parse through the rest of the page
-    while offset < length:
-        # At the start of each chunk is a pair of control bytes
-        chunk_control_bytes = input[offset:offset + CHUNK_CONTROL_SIZE_BYTES]
-        chunk_control_int = int.from_bytes(chunk_control_bytes, 'little')
-        if not chunk_control_bytes: break
-        chunk_expected_length = _get_expected_chunk_length(chunk_control_bytes)
+            '''
+            look_back_length = token_length - head
+            if (look_back_length > 0):
+                output.append(context[-look_back_length:])
+                token_length -= look_back_length
 
-        offset += CHUNK_CONTROL_SIZE_BYTES
-        chunk_data_bytes = input[offset:offset + chunk_expected_length]
-        chunk_actual_length = len(chunk_data_bytes)
-        offset += chunk_expected_length
+            output.append(output[])
+            '''
+        else:
+            output.append(data[token_index])
+    return output
 
-        context = output[-PAGE_CONTEXT_SIZE_BYTES:]
-        output += _decompress_chunk(context, chunk_control_int, chunk_data_bytes, chunk_actual_length)
+def _decompress_page(
+    input: memoryview
+) -> bytearray:
+    page_offset = 0
+    page_length = len(input)
+    output = bytearray()
 
-    # Return decompressed page bytes
+    # If this page is uncompressed, return the data portion as-is
+    page_control_bytes = memoryview(input[page_offset:page_offset + PAGE_HEADER_SIZE_BYTES])
+    page_offset += PAGE_HEADER_SIZE_BYTES
+    if (page_control_bytes[0] == 0x01): return memoryview(input[page_offset:])
+
+    # Otherwise decompress each chunk and append them
+    while (page_offset < page_length):
+        chunk_control_int = struct.unpack_from('H', input, page_offset)[0]
+        page_offset += 2
+        chunk_length = _get_expected_chunk_length(chunk_control_int)
+        chunk_data_bytes = input[page_offset:page_offset + chunk_length]
+        page_offset += chunk_length
+
+        output.append(_decompress_chunk(context=memoryview(output), 
+                                        control=chunk_control_int, 
+                                        data=chunk_data_bytes, 
+                                        length=chunk_length))
+
     return output
 
 def _decompress_stream(
-    input: bytearray,
+    input: memoryview,
     progress_desc: str = None,
     progress: Optional[Callable[[str, str, int, int], None]] = None
 ) -> bytearray:
-    output = bytearray()
-    length = len(input)
-    offset = 0
-    while offset < length:
-        # At the start of each page there is an 4 byte header to signify page length
-        page_size = int.from_bytes(input[offset:offset + PAGE_HEADER_SIZE_BYTES], byteorder='little')
-        offset += PAGE_HEADER_SIZE_BYTES
-        page_bytes = input[offset:offset + page_size]
-        offset += page_size
 
-        output += _decompress_page(page_bytes)
+    # Break the stream into a set of pages
+    stream_offset = 0
+    stream_length = len(input)
+    stream_pages_compressed = []
+    stream_pages_length = []
+    while (stream_offset < stream_length):
+        page_length = struct.unpack_from('I', input, stream_offset)[0]
+        stream_offset += 4
+        page_mv = memoryview(input[stream_offset:stream_offset + page_length])
+        stream_offset += page_length
+        stream_pages_compressed.append(page_mv)
+        stream_pages_length.append(page_length + 4)
+
+    # Decompress each page separately
+    # No context is shared across pages
+    stream_pages_decompressed = []
+    stream_pages_progress = 0
+    print(len(stream_pages_length))
+    for (page, length) in zip(stream_pages_compressed, stream_pages_length):
+        stream_pages_decompressed.append(_decompress_page(page))
         if progress:
+            stream_pages_progress += length
             desc = f'Decompressing'
             if progress_desc: desc += f' {progress_desc}'
-            progress(desc, 'bytes', length, offset)
+            progress(desc, 'bytes', stream_length, stream_pages_progress)
 
+    # Concatenate output
+    output = bytearray()
+    for page in stream_pages_decompressed: output.extend(page)
     return output
 
 def _create_subfolders(output_path: str, archive_paths: list[str]):
@@ -170,6 +211,7 @@ def decompress_archive(
             
             stream_data = ole.openstream(original_name).read()
             try:
+                print(stream_name)
                 stream_data = _decompress_stream(
                     input=stream_data,
                     progress_desc=stream_name,


### PR DESCRIPTION
Refactored some of the ME decompression methods to use memoryviews for slicing.  The decompress_stream() method now slices pages in advance, both to check for files that don't look right (aren't compressed) and so that pages can be processed in parallel.

Overall performance on my machine went from ~30 seconds to decompress a firmware image to ~5 seconds.